### PR TITLE
Add unit tests and fix several bugs

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "codecov": "^3.0.4",
     "core-js": "^2.5.7",
     "entypo": "^2.1.0",
+    "fetch-mock": "^7.0.0-alpha.6",
     "flow-bin": "^0.77.0",
     "git-exec-and-restage": "^1.1.1",
     "husky": "^1.0.0-rc.13",

--- a/src/lib/Use.js
+++ b/src/lib/Use.js
@@ -74,9 +74,13 @@ class Use extends React.Component<Props, State> {
     if (!parsedDocument) {
       try {
         parsedDocument = document.implementation.createHTMLDocument("");
-        parsedDocument.body.innerHTML = await (await fetch(resource, {
+        const response = await fetch(resource, {
           mode: "same-origin"
-        })).text();
+        });
+        if (!response.ok) {
+          return; // state is either { loaded: false } or managed by a later request
+        }
+        parsedDocument.body.innerHTML = await response.text();
         parsedDocument.domain = document.domain;
       } catch (e) {
         return; // state is either { loaded: false } or managed by a later request

--- a/src/lib/Use.js
+++ b/src/lib/Use.js
@@ -13,7 +13,8 @@ type Props = {
 };
 
 type State = {
-  loaded: boolean
+  loaded: boolean,
+  content: ?Array<Node>
 };
 
 function getHref(props: Props): ?string {
@@ -102,15 +103,14 @@ class Use extends React.Component<Props, State> {
       if (viewBox) {
         setViewBox(viewBox);
       }
-      const fragment = document.createDocumentFragment();
 
       const clone = template.cloneNode(true);
-
+      const contentNodes = [];
       while (clone.childNodes.length) {
-        fragment.appendChild(clone.firstChild);
+        contentNodes.push(clone.removeChild(clone.firstChild));
       }
 
-      this.setState({ loaded: true, content: fragment });
+      this.setState({ loaded: true, content: contentNodes });
     } else {
       this.setState({ loaded: true, content: undefined });
     }
@@ -125,12 +125,14 @@ class Use extends React.Component<Props, State> {
     const element = this._element.current;
     if (this.state.loaded && element) {
       const { content } = this.state;
-      if (!content || content.firstChild !== element.firstChild) {
+      if (!content || content[0] !== element.firstChild) {
         while (element.firstChild) {
           element.removeChild(element.firstChild);
         }
-        if (this.state.content) {
-          element.appendChild(this.state.content);
+        if (content) {
+          for (const node of content) {
+            element.appendChild(node);
+          }
         }
       }
     }

--- a/src/lib/Use.js
+++ b/src/lib/Use.js
@@ -78,7 +78,7 @@ class Use extends React.Component<Props, State> {
           mode: "same-origin"
         });
         if (!response.ok) {
-          return; // state is either { loaded: false } or managed by a later request
+          throw new Error(response.statusText);
         }
         parsedDocument.body.innerHTML = await response.text();
         parsedDocument.domain = document.domain;

--- a/src/lib/Use.js
+++ b/src/lib/Use.js
@@ -47,6 +47,8 @@ class Use extends React.Component<Props, State> {
       content: undefined // Hygiene
     });
 
+    // TODO: Remove this in favour of fetch(..., {mode: "same-origin"}) when popular fetch
+    // polyfills actually respect this mode!
     const windowOrigin =
       window.location.origin ||
       // IE < 11
@@ -70,7 +72,9 @@ class Use extends React.Component<Props, State> {
     if (!parsedDocument) {
       try {
         parsedDocument = document.implementation.createHTMLDocument("");
-        parsedDocument.body.innerHTML = await (await fetch(resource)).text();
+        parsedDocument.body.innerHTML = await (await fetch(resource, {
+          mode: "same-origin"
+        })).text();
         parsedDocument.domain = document.domain;
       } catch (e) {
         return; // state is either { loaded: false } or managed by a later request

--- a/src/lib/Use.js
+++ b/src/lib/Use.js
@@ -14,7 +14,8 @@ type Props = {
 
 type State = {
   loaded: boolean,
-  content: ?Array<Node>
+  content: ?Array<Node>,
+  viewBox: ?string
 };
 
 function getHref(props: Props): ?string {
@@ -31,7 +32,7 @@ class Use extends React.Component<Props, State> {
   async _load(href: ?string) {
     if (!href || href[0] === "#") {
       // Our fallback to <use> will do in these cases
-      this.setState({ loaded: false, content: undefined });
+      this.setState({ loaded: false, content: undefined, viewBox: undefined });
       return;
     }
     this._href = href;
@@ -44,7 +45,8 @@ class Use extends React.Component<Props, State> {
 
     this.setState({
       loaded: false,
-      content: undefined // Hygiene
+      content: undefined, // Hygiene
+      viewBox: undefined
     });
 
     // TODO: Remove this in favour of fetch(..., {mode: "same-origin"}) when popular fetch
@@ -94,14 +96,6 @@ class Use extends React.Component<Props, State> {
       // • Make sure to break circular references, in line with the SVG spec.
       // • Generalise most of the code that currently makes up `Use._load`, as it is directly applicable
       //   to resolving external references from a DOM context as well.
-      const {
-        svgContext: { setViewBox }
-      } = this.props;
-
-      const viewBox = template.getAttribute("viewBox");
-      if (viewBox) {
-        setViewBox(viewBox);
-      }
 
       const clone = template.cloneNode(true);
       const contentNodes = [];
@@ -109,9 +103,11 @@ class Use extends React.Component<Props, State> {
         contentNodes.push(clone.removeChild(clone.firstChild));
       }
 
-      this.setState({ loaded: true, content: contentNodes });
+      const viewBox = template.getAttribute("viewBox");
+
+      this.setState({ loaded: true, content: contentNodes, viewBox });
     } else {
-      this.setState({ loaded: true, content: undefined });
+      this.setState({ loaded: true, content: undefined, viewBox: undefined });
     }
   }
 
@@ -134,6 +130,10 @@ class Use extends React.Component<Props, State> {
           }
         }
       }
+    }
+    const { viewBox } = this.state;
+    if (viewBox !== prevState.viewBox) {
+      this.props.svgContext.setViewBox(viewBox);
     }
   }
 

--- a/src/lib/Use.js
+++ b/src/lib/Use.js
@@ -34,9 +34,6 @@ class Use extends React.Component<Props, State> {
       this.setState({ loaded: false, content: undefined });
       return;
     }
-    if (this._href === href && this.state.loaded) {
-      return;
-    }
     this._href = href;
     const hrefUrl = url.parse(
       url.resolve(typeof window === "object" ? window.location.href : "", href)
@@ -74,9 +71,7 @@ class Use extends React.Component<Props, State> {
       try {
         parsedDocument = document.implementation.createHTMLDocument("");
         parsedDocument.body.innerHTML = await (await fetch(resource)).text();
-        if (parsedDocument.domain !== document.domain) {
-          parsedDocument.domain = document.domain;
-        }
+        parsedDocument.domain = document.domain;
       } catch (e) {
         return; // state is either { loaded: false } or managed by a later request
       }

--- a/src/lib/__tests__/Svg.test.js
+++ b/src/lib/__tests__/Svg.test.js
@@ -21,6 +21,6 @@ describe("Svg", () => {
 
     render(<Svg ref={ref} />);
     expect(ref.current).toBeInstanceOf(Element);
-    expect(ref.current.tagName).toBe("svg");
+    expect(ref.current.tagName).toMatch(/^svg$/i);
   });
 });

--- a/src/lib/__tests__/Use.test.js
+++ b/src/lib/__tests__/Use.test.js
@@ -1,0 +1,365 @@
+import React from "react";
+import ReactDOMServer from "react-dom/server";
+import Use from "../Use";
+import Svg from "../Svg";
+import { render } from "react-testing-library";
+import fetchMock, { MATCHED, UNMATCHED } from "fetch-mock";
+import { resetCache } from "../getCache";
+
+beforeEach(resetCache);
+
+fetchMock.config.warnOnFallback = false;
+
+describe("Use polyfill", () => {
+  describe("without external URL", () => {
+    test("should render a <use> element", () => {
+      const { container } = render(<Use />);
+      expect(container.firstChild).toMatchSnapshot();
+    });
+    test("renders a local xlink:href", () => {
+      const { container } = render(<Use xlinkHref="#foo" />);
+      expect(container.firstChild).toMatchSnapshot();
+    });
+    test("renders a local href", () => {
+      const { container } = render(<Use href="#foo" />);
+      expect(container.firstChild).toMatchSnapshot();
+    });
+    test("renders both types of xlink:href", () => {
+      const { container } = render(<Use xlinkHref="#foo" />);
+      expect(container.firstChild).toMatchSnapshot();
+    });
+    test("should pass through attributes", () => {
+      const { container } = render(<Use data-foo="bar" viewBox="0 0 1 1" />);
+      expect(container.firstChild).toMatchSnapshot();
+    });
+    test("should expose a <use> ref", () => {
+      const ref = React.createRef();
+
+      render(<Use ref={ref} />);
+      expect(ref.current).toBeInstanceOf(Element);
+      expect(ref.current.tagName).toMatch(/^use$/i);
+    });
+  });
+  describe("with external URL", () => {
+    // NOTE: This assumes Jest's testURL is set to the default of "http://localhost"
+    beforeEach(() => {
+      fetchMock.getOnce(
+        (url, opts) =>
+          url === "http://localhost/sprites.svg" && opts.mode === "same-origin",
+        {
+          headers: {
+            "content-type": "image/svg+xml"
+          },
+          body: ReactDOMServer.renderToStaticMarkup(
+            <svg xmlns="http://www.w3.org/2000/svg" style={{ display: "none" }}>
+              <symbol viewBox="0 0 20 20" id="symbol-1">
+                <circle cx="10" cy="10" r="10" stroke="black" fill="red" />
+              </symbol>
+              <symbol id="symbol-2">
+                <ellipse
+                  cx="10"
+                  cy="10"
+                  rx="10"
+                  ry="5"
+                  stroke="black"
+                  fill="red"
+                />
+              </symbol>
+            </svg>
+          )
+        }
+      );
+      fetchMock.getOnce(
+        (url, opts) =>
+          url === "http://localhost/sprites-slow.svg" &&
+          opts.mode === "same-origin",
+        async () => {
+          await new Promise(resolve => setTimeout(resolve, 200));
+          return {
+            headers: {
+              "content-type": "image/svg+xml"
+            },
+            body: ReactDOMServer.renderToStaticMarkup(
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                style={{ display: "none" }}
+              >
+                <symbol viewBox="0 0 20 20" id="symbol-slow-1">
+                  <circle cx="10" cy="10" r="10" stroke="green" fill="yellow" />
+                </symbol>
+              </svg>
+            )
+          };
+        }
+      );
+      fetchMock.getOnce(
+        (url, opts) =>
+          url === "http://localhost/sprites-404.svg" &&
+          opts.mode === "same-origin",
+        404
+      );
+    });
+    afterEach(() => {
+      fetchMock.reset();
+    });
+    test("should request the external resource via href", async () => {
+      render(
+        <Svg>
+          <Use href="http://localhost/sprites.svg#symbol-1" />
+        </Svg>
+      );
+      await fetchMock.flush();
+      expect(fetchMock.called(MATCHED)).toBe(true);
+    });
+    test("should request the external resource via xlinkHref", async () => {
+      render(
+        <Svg>
+          <Use xlinkHref="http://localhost/sprites.svg#symbol-1" />
+        </Svg>
+      );
+      await fetchMock.flush();
+      expect(fetchMock.called(MATCHED)).toBe(true);
+    });
+    test("should prefer the href prop when requesting a resource", async () => {
+      render(
+        <Svg>
+          <Use
+            href="http://localhost/sprites.svg#symbol-1"
+            xlinkHref="http://localhost/sprites-nope.svg#symbol-1"
+          />
+        </Svg>
+      );
+      await fetchMock.flush();
+      expect(fetchMock.called(MATCHED)).toBe(true);
+      expect(fetchMock.called(UNMATCHED)).toBe(false);
+    });
+    test("should not request a cross-origin resource", async () => {
+      render(
+        <Svg>
+          <Use href="http://www.example.com/sprites.svg#symbol-1" />
+        </Svg>
+      );
+      await fetchMock.flush();
+      expect(fetchMock.called(MATCHED)).toBe(false);
+    });
+    describe("emulating missing location.origin", () => {
+      // IE 11 doesn't support location.origin
+      beforeAll(() => {
+        const originProp = Object.getOwnPropertyDescriptor(
+          window.location,
+          "origin"
+        );
+        Object.defineProperty(window.location, "origin", {
+          configurable: true,
+          value: undefined
+        });
+      });
+      afterAll(() => {
+        delete window.location.origin;
+        if (originProp) {
+          Object.defineProperty(window.location, "origin", originProp);
+        }
+      });
+      test("should not request a cross-origin resource", async () => {
+        render(
+          <Svg>
+            <Use href="http://www.example.com/sprites.svg#symbol-1" />
+          </Svg>
+        );
+        await fetchMock.flush();
+        expect(fetchMock.called(MATCHED)).toBe(false);
+      });
+    });
+    test.skip("should cache the external resource across synchronous renders", async () => {
+      // FIXME: This inadvertently hits an edge case where rerendering before the response is fully
+      // handled causes an unintended cache miss. TODO: Rewrite internals to use DataLoader
+      // instead.
+      const { rerender } = render(
+        <Svg>
+          <Use href="http://localhost/sprites.svg#symbol-1" />
+        </Svg>
+      );
+      rerender(
+        <Svg>
+          <Use href="http://localhost/sprites.svg#symbol-nope" />
+        </Svg>
+      );
+      await fetchMock.flush();
+      expect(fetchMock.calls(MATCHED)).toHaveLength(1);
+    });
+    test("should cache the external resource across renders", async () => {
+      const { rerender } = render(
+        <Svg>
+          <Use href="http://localhost/sprites.svg#symbol-1" />
+        </Svg>
+      );
+      await fetchMock.flush();
+      await Promise.resolve();
+      rerender(
+        <Svg>
+          <Use href="http://localhost/sprites.svg#symbol-nope" />
+        </Svg>
+      );
+      await fetchMock.flush();
+      expect(fetchMock.calls(MATCHED)).toHaveLength(1);
+    });
+    test("should render a plain <use> tag while loading", () => {
+      const { container } = render(
+        <Svg>
+          <Use href="http://localhost/sprites.svg#symbol-1" />
+        </Svg>
+      );
+      expect(container.firstChild).toMatchSnapshot();
+    });
+    test("should embed the referenced symbol in the output", async () => {
+      const { container } = render(
+        <Svg>
+          <Use href="http://localhost/sprites.svg#symbol-1" />
+        </Svg>
+      );
+      await fetchMock.flush();
+      await Promise.resolve(); // Let components handle response
+      expect(container.firstChild).toMatchSnapshot();
+    });
+    test("should pass props through to the embedded symbol", async () => {
+      const { container } = render(
+        <Svg>
+          <Use href="http://localhost/sprites.svg#symbol-1" data-foo="bar" />
+        </Svg>
+      );
+      await fetchMock.flush();
+      await Promise.resolve(); // Let components handle response
+      expect(container.firstChild).toMatchSnapshot();
+    });
+    test("should expose a <g> ref once loaded", async () => {
+      const ref = React.createRef();
+      render(
+        <Svg>
+          <Use ref={ref} href="http://localhost/sprites.svg#symbol-1" />
+        </Svg>
+      );
+      await fetchMock.flush();
+      await Promise.resolve(); // Let components handle response
+      expect(ref.current).toBeInstanceOf(Element);
+      expect(ref.current.tagName).toMatch(/^g$/i);
+    });
+    test("should output <g /> if the referenced symbol doesn't exist", async () => {
+      const { container } = render(
+        <Svg>
+          <Use href="http://localhost/sprites.svg#symbol-nope" />
+        </Svg>
+      );
+      await fetchMock.flush();
+      await Promise.resolve(); // Let components handle response
+      expect(container.firstChild).toMatchSnapshot();
+    });
+    test("should fall back to <use /> if the request hits a network error", async () => {
+      const { container } = render(
+        <Svg>
+          <Use href="http://localhost/sprites-nope.svg" />
+        </Svg>
+      );
+      await fetchMock.flush();
+      await Promise.resolve(); // Let components handle response
+      expect(container.firstChild).toMatchSnapshot();
+    });
+    test("should fall back to <use /> if the request hits a 404", async () => {
+      const { container } = render(
+        <Svg>
+          <Use href="http://localhost/sprites-404.svg" />
+        </Svg>
+      );
+      await fetchMock.flush();
+      await Promise.resolve(); // Let components handle response
+      expect(container.firstChild).toMatchSnapshot();
+    });
+    test("should not change if rerendering with the same href", async () => {
+      const { container, rerender } = render(
+        <Svg>
+          <Use href="http://localhost/sprites.svg#symbol-1" />
+        </Svg>
+      );
+      await fetchMock.flush();
+      await Promise.resolve(); // Let components handle response
+      const reference = container.cloneNode(true);
+      rerender(
+        <Svg>
+          <Use
+            // Change the prop from href to xlinkHref to force a (shallow) rerender
+            xlinkHref="http://localhost/sprites.svg#symbol-1"
+          />
+        </Svg>
+      );
+      // Guard against a flash of blank content because of the rerender.
+      expect(container).toContainHTML(reference.innerHTML);
+
+      // Guard against an async load getting triggered at all.
+      await fetchMock.flush();
+      await Promise.resolve();
+      expect(fetchMock.called(UNMATCHED)).toBe(false);
+      expect(container).toContainHTML(reference.innerHTML);
+    });
+    test("tracks the latest href despite another fetch completing later", async () => {
+      const { container, rerender } = render(
+        <Svg>
+          <Use href="http://localhost/sprites-slow.svg#symbol-slow-1" />
+        </Svg>
+      );
+      rerender(
+        <Svg>
+          <Use href="http://localhost/sprites.svg#symbol-1" />
+        </Svg>
+      );
+      await fetchMock.flush();
+      expect(fetchMock.calls(MATCHED)).toHaveLength(2);
+      await Promise.resolve(); // Let components handle response
+      expect(container.firstChild).toMatchSnapshot();
+    });
+    test("tracks the latest href despite another fetch completing sooner", async () => {
+      const { container, rerender } = render(
+        <Svg>
+          <Use href="http://localhost/sprites.svg#symbol-1" />
+        </Svg>
+      );
+      rerender(
+        <Svg>
+          <Use href="http://localhost/sprites-slow.svg#symbol-slow-1" />
+        </Svg>
+      );
+      await fetchMock.flush();
+      expect(fetchMock.calls(MATCHED)).toHaveLength(2);
+      await Promise.resolve(); // Let components handle response
+      expect(container.firstChild).toMatchSnapshot();
+    });
+    describe("viewBox", () => {
+      test("should set and clear as appropriate", async () => {
+        const { container, rerender } = render(
+          <Svg>
+            <Use href="http://localhost/sprites.svg#symbol-1" />
+          </Svg>
+        );
+        await fetchMock.flush();
+        await Promise.resolve(); // Let components handle response
+        expect(container.firstChild).toMatchSnapshot();
+        rerender(
+          <Svg>
+            <Use href="http://localhost/sprites.svg#symbol-2" />
+          </Svg>
+        );
+        await fetchMock.flush();
+        await Promise.resolve(); // Let components handle response
+        expect(container.firstChild).toMatchSnapshot();
+      });
+      test("should not override Svg's viewBox", async () => {
+        const { container, rerender } = render(
+          <Svg viewBox="1 2 3 4">
+            <Use href="http://localhost/sprites.svg#symbol-1" />
+          </Svg>
+        );
+        await fetchMock.flush();
+        await Promise.resolve(); // Let components handle response
+        expect(container.firstChild).toMatchSnapshot();
+      });
+    });
+  });
+});

--- a/src/lib/__tests__/__snapshots__/Use.test.js.snap
+++ b/src/lib/__tests__/__snapshots__/Use.test.js.snap
@@ -1,0 +1,171 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Use polyfill with external URL should embed the referenced symbol in the output 1`] = `
+<svg
+  viewBox="0 0 20 20"
+>
+  <g>
+    <circle
+      cx="10"
+      cy="10"
+      r="10"
+      stroke="black"
+      fill="red"
+    />
+  </g>
+</svg>
+`;
+
+exports[`Use polyfill with external URL should fall back to <use /> if the request hits a 404 1`] = `
+<svg>
+  <use
+    href="http://localhost/sprites-404.svg"
+  />
+</svg>
+`;
+
+exports[`Use polyfill with external URL should fall back to <use /> if the request hits a network error 1`] = `
+<svg>
+  <use
+    href="http://localhost/sprites-nope.svg"
+  />
+</svg>
+`;
+
+exports[`Use polyfill with external URL should output <g /> if the referenced symbol doesn't exist 1`] = `
+<svg>
+  <g />
+</svg>
+`;
+
+exports[`Use polyfill with external URL should pass props through to the embedded symbol 1`] = `
+<svg
+  viewBox="0 0 20 20"
+>
+  <g
+    data-foo="bar"
+  >
+    <circle
+      cx="10"
+      cy="10"
+      r="10"
+      stroke="black"
+      fill="red"
+    />
+  </g>
+</svg>
+`;
+
+exports[`Use polyfill with external URL should render a plain <use> tag while loading 1`] = `
+<svg>
+  <use
+    href="http://localhost/sprites.svg#symbol-1"
+  />
+</svg>
+`;
+
+exports[`Use polyfill with external URL tracks the latest href despite another fetch completing later 1`] = `
+<svg
+  viewBox="0 0 20 20"
+>
+  <g>
+    <circle
+      cx="10"
+      cy="10"
+      r="10"
+      stroke="black"
+      fill="red"
+    />
+  </g>
+</svg>
+`;
+
+exports[`Use polyfill with external URL tracks the latest href despite another fetch completing sooner 1`] = `
+<svg
+  viewBox="0 0 20 20"
+>
+  <g>
+    <circle
+      cx="10"
+      cy="10"
+      r="10"
+      stroke="green"
+      fill="yellow"
+    />
+  </g>
+</svg>
+`;
+
+exports[`Use polyfill with external URL viewBox should not override Svg's viewBox 1`] = `
+<svg
+  viewBox="1 2 3 4"
+>
+  <g>
+    <circle
+      cx="10"
+      cy="10"
+      r="10"
+      stroke="black"
+      fill="red"
+    />
+  </g>
+</svg>
+`;
+
+exports[`Use polyfill with external URL viewBox should set and clear as appropriate 1`] = `
+<svg
+  viewBox="0 0 20 20"
+>
+  <g>
+    <circle
+      cx="10"
+      cy="10"
+      r="10"
+      stroke="black"
+      fill="red"
+    />
+  </g>
+</svg>
+`;
+
+exports[`Use polyfill with external URL viewBox should set and clear as appropriate 2`] = `
+<svg>
+  <g>
+    <ellipse
+      cx="10"
+      cy="10"
+      rx="10"
+      ry="5"
+      stroke="black"
+      fill="red"
+    />
+  </g>
+</svg>
+`;
+
+exports[`Use polyfill without external URL renders a local href 1`] = `
+<use
+  href="#foo"
+/>
+`;
+
+exports[`Use polyfill without external URL renders a local xlink:href 1`] = `
+<use
+  xlink:href="#foo"
+/>
+`;
+
+exports[`Use polyfill without external URL renders both types of xlink:href 1`] = `
+<use
+  xlink:href="#foo"
+/>
+`;
+
+exports[`Use polyfill without external URL should pass through attributes 1`] = `
+<use
+  data-foo="bar"
+  viewbox="0 0 1 1"
+/>
+`;
+
+exports[`Use polyfill without external URL should render a <use> element 1`] = `<use />`;

--- a/src/lib/getCache.js
+++ b/src/lib/getCache.js
@@ -8,3 +8,7 @@ export default function getCache() {
   }
   return cacheNamespace[CACHE_KEY];
 }
+
+export function resetCache() {
+  delete cacheNamespace[CACHE_KEY];
+}

--- a/src/lib/getCache.js
+++ b/src/lib/getCache.js
@@ -1,6 +1,7 @@
 const CACHE_KEY = "__SVG_USE_DOCUMENT_CACHE__";
 
-const cacheNamespace = typeof document === "object" ? document : {};
+const cacheNamespace =
+  typeof document === "object" ? document : /* istanbul ignore next */ {};
 
 export default function getCache() {
   if (!cacheNamespace[CACHE_KEY]) {

--- a/src/setupTests.js
+++ b/src/setupTests.js
@@ -1,2 +1,5 @@
 import "jest-dom/extend-expect";
 import "react-testing-library/cleanup-after-each";
+import fetchMock from "fetch-mock";
+
+afterEach(fetchMock.resetHistory);

--- a/yarn.lock
+++ b/yarn.lock
@@ -3168,6 +3168,15 @@ fbjs@^0.8.16:
     setimmediate "^1.0.5"
     ua-parser-js "^0.7.18"
 
+fetch-mock@^7.0.0-alpha.6:
+  version "7.0.0-alpha.6"
+  resolved "https://registry.yarnpkg.com/fetch-mock/-/fetch-mock-7.0.0-alpha.6.tgz#5c08d0409c6e9cde1bf5bb4a5002af7a3625fe8c"
+  dependencies:
+    babel-polyfill "^6.26.0"
+    glob-to-regexp "^0.4.0"
+    path-to-regexp "^2.2.1"
+    whatwg-url "^6.5.0"
+
 figures@^1.7.0:
   version "1.7.0"
   resolved "https://registry.yarnpkg.com/figures/-/figures-1.7.0.tgz#cbe1e3affcf1cd44b80cadfed28dc793a9701d2e"
@@ -3509,6 +3518,10 @@ glob-parent@^3.1.0:
 glob-to-regexp@^0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/glob-to-regexp/-/glob-to-regexp-0.3.0.tgz#8c5a1494d2066c570cc3bfe4496175acc4d502ab"
+
+glob-to-regexp@^0.4.0:
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/glob-to-regexp/-/glob-to-regexp-0.4.0.tgz#49bd677b1671022bd10921c3788f23cdebf9c7e6"
 
 glob@^7.0.3, glob@^7.0.5, glob@^7.1.1, glob@^7.1.2:
   version "7.1.2"
@@ -5082,6 +5095,10 @@ lodash.memoize@^4.1.2:
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/lodash.memoize/-/lodash.memoize-4.1.2.tgz#bcc6c49a42a2840ed997f323eada5ecd182e0bfe"
 
+lodash.sortby@^4.7.0:
+  version "4.7.0"
+  resolved "https://registry.yarnpkg.com/lodash.sortby/-/lodash.sortby-4.7.0.tgz#edd14c824e2cc9c1e0b0a1b42bb5210516a42438"
+
 lodash.template@^4.4.0:
   version "4.4.0"
   resolved "https://registry.yarnpkg.com/lodash.template/-/lodash.template-4.4.0.tgz#e73a0385c8355591746e020b99679c690e68fba0"
@@ -6032,6 +6049,10 @@ path-to-regexp@^1.0.1:
   resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-1.7.0.tgz#59fde0f435badacba103a84e9d3bc64e96b9937d"
   dependencies:
     isarray "0.0.1"
+
+path-to-regexp@^2.2.1:
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-2.4.0.tgz#35ce7f333d5616f1c1e1bfe266c3aba2e5b2e704"
 
 path-type@^1.0.0:
   version "1.1.0"
@@ -7937,6 +7958,12 @@ tough-cookie@~2.3.3:
   dependencies:
     punycode "^1.4.1"
 
+tr46@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/tr46/-/tr46-1.0.1.tgz#a8b13fd6bfd2489519674ccde55ba3693b706d09"
+  dependencies:
+    punycode "^2.1.0"
+
 tr46@~0.0.3:
   version "0.0.3"
   resolved "https://registry.yarnpkg.com/tr46/-/tr46-0.0.3.tgz#8184fd347dac9cdc185992f3a6622e14b9d9ab6a"
@@ -8266,7 +8293,7 @@ webidl-conversions@^3.0.0:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-3.0.1.tgz#24534275e2a7bc6be7bc86611cc16ae0a5654871"
 
-webidl-conversions@^4.0.0:
+webidl-conversions@^4.0.0, webidl-conversions@^4.0.2:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-4.0.2.tgz#a855980b1f0b6b359ba1d5d9fb39ae941faa63ad"
 
@@ -8384,6 +8411,14 @@ whatwg-url@^4.3.0:
   dependencies:
     tr46 "~0.0.3"
     webidl-conversions "^3.0.0"
+
+whatwg-url@^6.5.0:
+  version "6.5.0"
+  resolved "https://registry.yarnpkg.com/whatwg-url/-/whatwg-url-6.5.0.tgz#f2df02bff176fd65070df74ad5ccbb5a199965a8"
+  dependencies:
+    lodash.sortby "^4.7.0"
+    tr46 "^1.0.1"
+    webidl-conversions "^4.0.2"
 
 whet.extend@~0.9.9:
   version "0.9.9"


### PR DESCRIPTION
Writing these tests uncovered several bugs which are fixed in this branch.

Resolves #1. This doesn't directly do anything about #5 (the main missing feature) except lay the groundwork for confident iteration.

Still to do before merging:
- [x] Open an issue (#21) corresponding to the failing test (skipped here) `Use polyfill should cache the external resource across synchronous renders`.
- [x] Add a test (f96e26e) with relative URLs in `href`.
- [ ] Maybe add `console.error` mocking and assertions around cross-origin requests (which are strictly disallowed).
- [ ] Final code review for clarity.
